### PR TITLE
Fix resource_create, resource_patch API calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ first. Run next command from extension folder:
 
 For CKAN>=2.9 use the following command instead:
 
-    ckan -c /etc/ckan/default/production.ini ` db upgrade -p cloudstorage
+    ckan -c /etc/ckan/default/production.ini db upgrade -p cloudstorage
 
 With that feature you can use `cloudstorage_clean_multipart` action, which is available
 only for sysadmins. After executing, all unfinished multipart uploads, older than 7 days,

--- a/ckanext/cloudstorage/helpers.py
+++ b/ckanext/cloudstorage/helpers.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from ckanext.cloudstorage.storage import ResourceCloudStorage
-
+import ckan.plugins.toolkit as tk
 
 def use_secure_urls():
     return all([
@@ -10,3 +10,7 @@ def use_secure_urls():
         'S3' in ResourceCloudStorage.driver_name.fget(None),
         'host' in ResourceCloudStorage.driver_options.fget(None),
     ])
+
+
+def use_multipart_upload():
+    return use_secure_urls()

--- a/ckanext/cloudstorage/plugin/__init__.py
+++ b/ckanext/cloudstorage/plugin/__init__.py
@@ -33,7 +33,10 @@ class CloudStoragePlugin(MixinPlugin, plugins.SingletonPlugin):
     # ITemplateHelpers
 
     def get_helpers(self):
-        return dict(cloudstorage_use_secure_urls=helpers.use_secure_urls)
+        return dict(
+            cloudstorage_use_secure_urls=helpers.use_secure_urls,
+            cloudstorage_use_multipart_upload=helpers.use_multipart_upload,
+        )
 
     # IConfigurable
 

--- a/ckanext/cloudstorage/templates/cloudstorage/snippets/multipart_module.html
+++ b/ckanext/cloudstorage/templates/cloudstorage/snippets/multipart_module.html
@@ -1,10 +1,12 @@
 <div
-    data-module="cloudstorage-multipart-upload"
-    data-module-cloud='S3'
-    {# prevent type-guessing inside JS module by prefixing ID with underscore #}
-    data-module-package-id="_{{ pkg_name }}"
-    data-module-max-size="{{ max_size }}"
-   >
+    {% if h.cloudstorage_use_multipart_upload() %}
+        data-module="cloudstorage-multipart-upload"
+        data-module-cloud='S3'
+        {# prevent type-guessing inside JS module by prefixing ID with underscore #}
+        data-module-package-id="_{{ pkg_name }}"
+        data-module-max-size="{{ max_size }}"
+    {% endif %}
+>
     {{ parent() }}
 
 </div>

--- a/ckanext/cloudstorage/tests/fixtures.py
+++ b/ckanext/cloudstorage/tests/fixtures.py
@@ -155,7 +155,7 @@ except ImportError:
             yield
 
     @pytest.fixture
-    def make_resource(clean_db, ckan_config, monkeypatch, tmpdir):
+    def create_with_upload(clean_db, ckan_config, monkeypatch, tmpdir):
         """Shortcut for creating uploaded resource.
         Requires content and name for newly created resource. By default
         is using `resource_create` action, but it can be changed by
@@ -165,8 +165,8 @@ except ImportError:
         additional named arguments, that will be used as resource
         properties.
         Example::
-            def test_uploaded_resource(make_resource):
-                resource = make_resource("hello world", "file.txt")
+            def test_uploaded_resource(create_with_upload):
+                resource = create_with_upload("hello world", "file.txt", package_id=factories.Dataset()['id'])
                 assert resource["url_type"] == "upload"
                 assert resource["format"] == "TXT"
                 assert resource["size"] == 11
@@ -186,7 +186,5 @@ except ImportError:
                 u"upload": test_resource,
             }
             params.update(kwargs)
-            if u'package_id' not in params:
-                params[u'package_id'] = factories.Dataset()[u"id"]
             return test_helpers.call_action(action, context, **params)
         return factory

--- a/ckanext/cloudstorage/tests/logic/action/test_multipart.py
+++ b/ckanext/cloudstorage/tests/logic/action/test_multipart.py
@@ -25,8 +25,7 @@ class TestMultipartUpload(object):
         storage = ResourceCloudStorage(res)
         assert storage.path_from_filename(
             res['id'], filename) == multipart['name']
-        with pytest.raises(ObjectDoesNotExistError):
-            storage.get_url_from_filename(res['id'], filename)
+        assert storage.get_url_from_filename(res['id'], filename) is None
 
         fp = six.BytesIO(b'b' * 1024 * 1024 * 5)
         fp.seek(0)
@@ -36,8 +35,7 @@ class TestMultipartUpload(object):
             partNumber=1,
             upload=FakeFileStorage(fp, filename))
 
-        with pytest.raises(ObjectDoesNotExistError):
-            storage.get_url_from_filename(res['id'], filename)
+        assert storage.get_url_from_filename(res['id'], filename) is None
 
         fp = six.BytesIO(b'a' * 1024 * 1024 * 5)
         fp.seek(0)
@@ -47,8 +45,7 @@ class TestMultipartUpload(object):
             partNumber=2,
             upload=FakeFileStorage(fp, filename))
 
-        with pytest.raises(ObjectDoesNotExistError):
-            storage.get_url_from_filename(res['id'], filename)
+        assert storage.get_url_from_filename(res['id'], filename) is None
 
         result = helpers.call_action(
             'cloudstorage_finish_multipart', uploadId=multipart['id'])

--- a/ckanext/cloudstorage/tests/test_plugin.py
+++ b/ckanext/cloudstorage/tests/test_plugin.py
@@ -28,19 +28,18 @@ class TestCloudstoragePlugin(object):
             plugin.configure(ckan_config)
 
     @pytest.mark.usefixtures('clean_db')
-    def test_before_delete(self, make_resource):
+    def test_before_delete(self, create_with_upload):
         """When resource deleted, we must remove corresponding file from S3.
 
         """
         name = 'test.txt'
-        resource = make_resource('hello world', name, name=name)
+        resource = create_with_upload('hello world', name, name=name, package_id=factories.Dataset()['id'])
         plugin = p.get_plugin('cloudstorage')
         uploader = plugin.get_resource_uploader(resource)
         assert uploader.get_url_from_filename(resource['id'], name)
 
         helpers.call_action('resource_delete', id=resource['id'])
-        with pytest.raises(ObjectDoesNotExistError):
-            assert uploader.get_url_from_filename(resource['id'], name)
+        assert uploader.get_url_from_filename(resource['id'], name) is None
 
     @pytest.mark.usefixtures('clean_db')
     def test_before_delete_for_linked_resource(self):

--- a/ckanext/cloudstorage/tests/test_storage.py
+++ b/ckanext/cloudstorage/tests/test_storage.py
@@ -2,6 +2,7 @@
 import pytest
 
 from six.moves.urllib.parse import urlparse
+from ckan.tests import factories
 
 from ckanext.cloudstorage.storage import CloudStorage, ResourceCloudStorage
 
@@ -23,20 +24,32 @@ class TestCloudStorage(object):
 @pytest.mark.ckan_config('ckan.plugins', 'cloudstorage')
 @pytest.mark.usefixtures('with_driver_options', 'with_plugins')
 class TestResourceCloudStorage(object):
-    def test_not_secure_url_from_filename(self, make_resource):
+    def test_not_secure_url_from_filename(self, create_with_upload):
         filename = 'file.txt'
-        resource = make_resource('test', filename)
+        resource = create_with_upload('test', filename, package_id=factories.Dataset()['id'])
         storage = ResourceCloudStorage(resource)
         url = storage.get_url_from_filename(resource['id'], filename)
         assert storage.container_name in url
         assert not urlparse(url).query
 
     @pytest.mark.ckan_config('ckanext.cloudstorage.use_secure_urls', True)
-    def test_secure_url_from_filename(self, make_resource):
+    def test_secure_url_from_filename(self, create_with_upload):
         filename = 'file.txt'
-        resource = make_resource('test', filename)
+        resource = create_with_upload('test', filename, package_id=factories.Dataset()['id'])
         storage = ResourceCloudStorage(resource)
         if not storage.can_use_advanced_aws or not storage.use_secure_urls:
             pytest.skip('SecureURL not supported')
         url = storage.get_url_from_filename(resource['id'], filename)
+        assert urlparse(url).query
+
+    @pytest.mark.ckan_config('ckanext.cloudstorage.use_secure_urls', True)
+    def test_hash_check(self, create_with_upload):
+        filename = 'file.txt'
+        resource = create_with_upload('test', filename, package_id=factories.Dataset()['id'])
+        storage = ResourceCloudStorage(resource)
+        if not storage.can_use_advanced_aws or not storage.use_secure_urls:
+            pytest.skip('SecureURL not supported')
+        url = storage.get_url_from_filename(resource['id'], filename)
+        resource = create_with_upload('test', filename, action='resource_update', id=resource['id'])
+
         assert urlparse(url).query

--- a/ckanext/cloudstorage/tests/test_utils.py
+++ b/ckanext/cloudstorage/tests/test_utils.py
@@ -38,9 +38,9 @@ class TestResourceDownload(object):
         app.get(url, status=302, extra_environ=env, follow_redirects=False)
 
     @pytest.mark.usefixtures('clean_db')
-    def test_download(self, make_resource, app):
+    def test_download(self, create_with_upload, app):
         filename = 'file.txt'
-        resource = make_resource('hello world', filename)
+        resource = create_with_upload('hello world', filename, package_id=factories.Dataset()['id'])
         url = tk.url_for(
             'resource.download',
             id=resource['package_id'],

--- a/test.ini
+++ b/test.ini
@@ -16,7 +16,7 @@ use = config:../ckan/test-core.ini
 
 # Logging configuration
 [loggers]
-keys = root, ckan, sqlalchemy
+keys = root, ckan, sqlalchemy, ckanext
 
 [handlers]
 keys = console
@@ -46,3 +46,9 @@ formatter = generic
 
 [formatter_generic]
 format = %(asctime)s %(levelname)-5.5s [%(name)s] %(message)s
+
+[logger_ckanext]
+level = DEBUG
+handlers = console
+qualname = ckanext
+propagate = 0 


### PR DESCRIPTION
running `resource_create`, `resource_patch` API calls gives this traceback:
```
04:05:05,332 DEBUG [ckanext.googleanalytics.plugin] Sending API event to Google Analytics: v=1&tid=UA-87815428-4&cid=6c37a97f8e35600f0b933e3223acb625&t=event&dh=dev.landgate.links.com.au&dp=%2Fapi%2Faction%2Fresource_patch&dr=&ec=CKAN+API+Request&ea=resource_patch&el=c2a17f23-943c-4aba-b5f3-fa01d785e4da
	 Object found, checking size resources/c2a17f23-943c-4aba-b5f3-fa01d785e4da/dummy.pdf: 13264
04:05:05,664 ERROR [ckan.views.api] stat: path should be string, bytes, os.PathLike or integer, not NoneType
Traceback (most recent call last):
  File "/usr/lib/ckan-2.5.2/ckan-py3/src/ckan/ckan/config/middleware/../../views/api.py", line 291, in action
    result = function(context, request_data)
  File "/usr/lib/ckan-2.5.2/ckan-py3/src/ckan/ckan/logic/__init__.py", line 473, in wrapped
    result = _action(context, data_dict, **kw)
  File "/usr/lib/ckan-2.5.2/ckan-py3/src/ckan/ckan/logic/action/patch.py", line 80, in resource_patch
    return _update.resource_update(context, patched)
  File "/usr/lib/ckan-2.5.2/ckan-py3/src/ckan/ckan/logic/action/update.py", line 104, in resource_update
    updated_pkg_dict = _get_action('package_update')(context, pkg_dict)
  File "/usr/lib/ckan-2.5.2/ckan-py3/src/ckan/ckan/logic/__init__.py", line 473, in wrapped
    result = _action(context, data_dict, **kw)
  File "/usr/lib/ckan-2.5.2/ckan-py3/src/ckan/ckan/logic/action/update.py", line 325, in package_update
    upload.upload(resource['id'], uploader.get_max_resource_size())
  File "/usr/lib/ckan-2.5.2/ckan-py3/src/ckanext-cloudstorage/ckanext/cloudstorage/storage.py", line 303, in upload
    file_size = os.path.getsize(file_upload.name)
  File "/opt/pyenv/versions/3.8.4/lib/python3.8/genericpath.py", line 50, in getsize
    return os.stat(filename).st_size
TypeError: stat: path should be string, bytes, os.PathLike or integer, not NoneType
```

This change fixes it.